### PR TITLE
Fix duplicate /api prefixes

### DIFF
--- a/Backend/src/order_statuses.py
+++ b/Backend/src/order_statuses.py
@@ -3,7 +3,9 @@ from src.db import get_db_connection
 from src.schemas import OrderStatus, OrderStatusCreate
 from src.dependencies import require_role
 
-router = APIRouter(prefix="/api/order_statuses", tags=["order_statuses"])
+# This router is mounted under `/api` in `main.py`. Removing the redundant
+# `/api` avoids paths like `/api/api/order_statuses`.
+router = APIRouter(prefix="/order_statuses", tags=["order_statuses"])
 
 @router.get("/", response_model=list[OrderStatus], dependencies=[Depends(require_role([0]))])
 def get_statuses():

--- a/Backend/src/roles.py
+++ b/Backend/src/roles.py
@@ -3,7 +3,10 @@ from src.db import get_db_connection
 from src.schemas import Role, RoleCreate
 from src.dependencies import require_role
 
-router = APIRouter(prefix="/api/roles", tags=["roles"])
+# Prefix is added when the router is mounted under `/api` in `main.py`.
+# Using `/api/roles` here produced paths like `/api/api/roles`.
+# Correct prefix should not include `/api`.
+router = APIRouter(prefix="/roles", tags=["roles"])
 
 @router.get("/", response_model=list[Role], dependencies=[Depends(require_role([0]))])
 def get_roles():

--- a/Backend/src/toads.py
+++ b/Backend/src/toads.py
@@ -3,7 +3,8 @@ from src.db import get_db_connection
 from src.schemas import Toad, ToadCreate
 from src.dependencies import require_role
 
-router = APIRouter(prefix="/api/toads", tags=["toads"])
+# This router is mounted under `/api`, so the prefix should not repeat it.
+router = APIRouter(prefix="/toads", tags=["toads"])
 
 @router.get("/", response_model=list[Toad], dependencies=[Depends(require_role([0]))])
 def get_all_toads():

--- a/Backend/src/users.py
+++ b/Backend/src/users.py
@@ -3,7 +3,9 @@ from src.db import get_db_connection
 from src.schemas import User, UserCreate
 from src.dependencies import require_role
 
-router = APIRouter(prefix="/api/users", tags=["users"])
+# Routers are mounted under `/api` in `main.py`; using `/api/users` here
+# resulted in paths like `/api/api/users`. Use a relative prefix instead.
+router = APIRouter(prefix="/users", tags=["users"])
 
 
 @router.get("/", response_model=list[User], dependencies=[Depends(require_role([0]))])


### PR DESCRIPTION
## Summary
- fix router prefixes so endpoints are mounted correctly

## Testing
- `python3 -m py_compile Backend/src/roles.py Backend/src/toads.py Backend/src/users.py Backend/src/order_statuses.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f8cca73c8329b49a571ce148ec79