### PR TITLE
Add env configuration for service URLs

### DIFF
--- a/Backend/src/main.py
+++ b/Backend/src/main.py
@@ -24,16 +24,14 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
 app = FastAPI(redirect_slashes=False)
 
 # Configure CORS
-# Замените YOUR_IP_ADDRESS на IP-адрес вашего компьютера в локальной сети
+# Адреса фронтенда и бэкенда можно задать через переменные окружения
+frontend_url = os.getenv("FRONTEND_URL", "http://localhost:5173")
+backend_url = os.getenv("BACKEND_URL", "http://localhost:8000")
 
 origins = [
-    "http://localhost:5173",  # Vite dev server
-    "http://127.0.0.1:5173",
-    "http://localhost:8000",  # FastAPI backend
-    "http://127.0.0.1:8000",
-    "http://192.168.0.104:5173",  # Vite dev server on local network
-    "http://192.168.0.104:8000",  # FastAPI backend on local network
-    "*"  # Allow all origins during development
+    frontend_url,
+    backend_url,
+    "*",  # Allow all origins during development
 ]
 
 # origins = [

--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -3,6 +3,8 @@ FROM node:18-alpine AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
 COPY . .
 RUN npm run build
 

--- a/Frontend/api.js
+++ b/Frontend/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
-// Замените YOUR_IP_ADDRESS на IP-адрес вашего компьютера в локальной сети
-const API_BASE_URL = "http://127.0.0.1:8000";
+// Базовый адрес API задается через переменную окружения VITE_API_BASE_URL
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:8000";
 const api = axios.create({
   baseURL: API_BASE_URL,
   headers: {

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ DB_NAME=frog
 DB_USER=frog
 DB_PASSWORD=secret
 DB_PORT=5432
+BACKEND_PORT=8000
+FRONTEND_PORT=5173
+# URL, по которому фронтенд обращается к бэкенду
+VITE_API_BASE_URL=http://localhost:8000
 ```
 
 2. Соберите и запустите контейнеры:
@@ -35,5 +39,6 @@ DB_PORT=5432
 docker compose up --build
 ```
 
-Backend будет доступен на `http://localhost:8000`, frontend — на `http://localhost:5173`.
+Адреса сервисов можно изменить через `BACKEND_PORT` и `FRONTEND_PORT` в `.env`.
+По умолчанию backend будет доступен на `http://localhost:8000`, frontend — на `http://localhost:5173`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,22 +34,26 @@ services:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASSWORD: ${DB_PASSWORD}
+      FRONTEND_URL: http://localhost:${FRONTEND_PORT}
+      BACKEND_URL: http://localhost:${BACKEND_PORT}
     depends_on:
       - db
     ports:
-      - "8000:8000"
+      - "${BACKEND_PORT:-8000}:8000"
     networks:
       - backend
 
   frontend:
     build:
       context: ./Frontend
+      args:
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL}
     container_name: frog-cafe-frontend
     restart: unless-stopped
     depends_on:
       - backend
     ports:
-      - "5173:80"
+      - "${FRONTEND_PORT:-5173}:80"
     networks:
       - backend
 


### PR DESCRIPTION
## Summary
- allow customizing backend/frontend addresses
- pass API base URL during frontend build
- update CORS configuration in backend
- document new environment variables

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6888b2e677a8832986eff985db4bd051